### PR TITLE
Leave changelog note regarding recent clojure CVE

### DIFF
--- a/.sealog/changes/1-2-1.edn
+++ b/.sealog/changes/1-2-1.edn
@@ -1,0 +1,11 @@
+{:version      {:major 1
+                :minor 2
+                :patch 1}
+ :version-type :semver3
+ :changes      {:added      []
+                :changed    ["Bumped `org.clojure/clojure` to `1.11.2`. Note: Addressing `CVE-2024-22871` / `GHSA-vr64-r9qj-h27f` requires consumers to upgrade to this version."]
+                :deprecated []
+                :removed    []
+                :fixed      []
+                :security   []}
+ :timestamp    "2024-03-10T23:08:30.707682800Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [1.2.1 - 2024-03-10](#121---2024-03-10)
 * [1.2.0 - 2024-03-03](#120---2024-03-03)
 * [1.1.0 - 2024-02-19](#110---2024-02-19)
 * [1.0.2 - 2022-12-11](#102---2022-12-11)
 * [1.0.1 - 2022-10-23](#101---2022-10-23)
 * [1.0.0 - 2022-10-23](#100---2022-10-23)
+
+## 1.2.1 - 2024-03-10
+
+* Changed
+  * Bumped `org.clojure/clojure` to `1.11.2`. Note: Addressing `CVE-2024-22871` / `GHSA-vr64-r9qj-h27f` requires consumers to upgrade to this version.
 
 ## 1.2.0 - 2024-03-03
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>lein-sealog</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>lein-sealog</name>
   <description>A Leiningen plugin for managing your changelog.</description>
   <url>https://github.com/Wall-Brew-Co/common-beer-format</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/lein-sealog</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/lein-sealog.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/lein-sealog.git</developerConnection>
-    <tag>fbbb9f5108342b76fd7ca8329e72b7294c20ede4</tag>
+    <tag>cdb9bb5f378c18ce65c50612dbe9d78e5e15b53c</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/lein-sealog "1.2.0"
+(defproject com.wallbrew/lein-sealog "1.2.1"
   :description "A Leiningen plugin for managing your changelog."
   :url "https://github.com/Wall-Brew-Co/common-beer-format"
   :license {:name         "MIT"


### PR DESCRIPTION
# Proposed Changes

- Updates: Update to `clojure` 1.11.2 to resolve transitive dependency vulnerability alerts. Leave a note to consumers about upgrading to 1.11.2

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
