### PR TITLE
Remove Commas Automatically Inserted By pprint

### DIFF
--- a/.wallbrew/sealog/changes/1-7-0.edn
+++ b/.wallbrew/sealog/changes/1-7-0.edn
@@ -6,6 +6,6 @@
                 :changed    []
                 :deprecated []
                 :removed    []
-                :fixed      ["Added the `<orgnization>` tag to the pom.xml file."]
+                :fixed      ["Added the `<organization>` tag to the pom.xml file."]
                 :security   []}
  :timestamp    "2024-09-21T16:27:46.206002976Z"}

--- a/.wallbrew/sealog/changes/1-9-0.edn
+++ b/.wallbrew/sealog/changes/1-9-0.edn
@@ -1,0 +1,11 @@
+{:version      {:major 1
+                :minor 9
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["Added a new configuration key `:remove-commas-in-change-files?` to remove automatically printed commas in change entry files."]
+                :changed    []
+                :deprecated []
+                :removed    []
+                :fixed      []
+                :security   []}
+ :timestamp    "2025-01-20T17:55:02.695874Z"}

--- a/.wallbrew/sealog/config.edn
+++ b/.wallbrew/sealog/config.edn
@@ -1,4 +1,4 @@
 {:changelog-filename        "CHANGELOG.md"
  :changelog-entry-directory ".wallbrew/sealog/changes/"
  :version-scheme            :semver3
- :pretty-print-edn?         true}
+ :pretty-print-edn?         false}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [1.9.0 - 2025-01-20](#190---2025-01-20)
 * [1.8.0 - 2024-10-13](#180---2024-10-13)
 * [1.7.0 - 2024-09-21](#170---2024-09-21)
 * [1.6.0 - 2024-05-03](#160---2024-05-03)
@@ -19,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [1.0.1 - 2022-10-23](#101---2022-10-23)
 * [1.0.0 - 2022-10-23](#100---2022-10-23)
 
+## 1.9.0 - 2025-01-20
+
+* Added
+  * Added a new configuration key `:remove-commas-in-change-files?` to remove automatically printed commas in change entry files.
+
 ## 1.8.0 - 2024-10-13
 
 * Added
@@ -28,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## 1.7.0 - 2024-09-21
 
 * Fixed
-  * Added the `<orgnization>` tag to the pom.xml file.
+  * Added the `<organization>` tag to the pom.xml file.
 
 ## 1.6.0 - 2024-05-03
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sealog is available as a leiningen plugin and can be downloaded from [clojars](h
 To install Sealog, add the following in your `:plugins` list in your `project.clj` file:
 
 ```clj
-[com.wallbrew/lein-sealog "1.7.0"]
+[com.wallbrew/lein-sealog "1.9.0"]
 ```
 
 The first time you invoke this plugin, Leiningen will automatically fetch the dependency for you.
@@ -340,10 +340,10 @@ Long-term decisions, such as where the Changelog should be written to, can also 
 As of version `1.7.0`, Sealog will inspect the following locations for configuration.
 The first location found will be used, and the others will be ignored:
 
-- The `:sealog` key in the project's `project.clj` file
-- The `.sealog/config.edn` file, relative to the project's root
-- The `.wallbrew/sealog/config.edn` file, relative to the project's root
-- The default configuration that would be written by `lein sealog init`
+* The `:sealog` key in the project's `project.clj` file
+* The `.sealog/config.edn` file, relative to the project's root
+* The `.wallbrew/sealog/config.edn` file, relative to the project's root
+* The default configuration that would be written by `lein sealog init`
 
 Sealog will create this file while executing `lein sealog init` if no prior Sealog configuration file is detected.
 The file will be created with the defaults outlined in this README.
@@ -359,6 +359,8 @@ The following keys and values are supported:
     * `:semver3` - [3 Position Semantic Versioning 2.0](https://semver.org/)
 * `:pretty-print-edn?`
   * A boolean to determine if the .edn config and changelog entry files should be pretty printed. Defaults to false
+* `:remove-commas-in-change-files?`
+  * A boolean to remove the commas automatically inserted between key:value pairs in printed versions of changelog entry files. Defaults to false
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>lein-sealog</artifactId>
   <packaging>jar</packaging>
-  <version>1.8.1</version>
+  <version>1.9.0</version>
   <name>lein-sealog</name>
   <description>A Leiningen plugin for managing your changelog.</description>
   <url>https://github.com/Wall-Brew-Co/lein-sealog</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/lein-sealog</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/lein-sealog.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/lein-sealog.git</developerConnection>
-    <tag>bbe536c7aae10a7d5529a6792379df020f361beb</tag>
+    <tag>fc3e991b1c879dfed4d7bdc600c5ed732761ef95</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>lein-sealog</artifactId>
   <packaging>jar</packaging>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <name>lein-sealog</name>
   <description>A Leiningen plugin for managing your changelog.</description>
   <url>https://github.com/Wall-Brew-Co/lein-sealog</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/lein-sealog</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/lein-sealog.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/lein-sealog.git</developerConnection>
-    <tag>604d39fea1862e1c45710b238e5ecec831567913</tag>
+    <tag>bbe536c7aae10a7d5529a6792379df020f361beb</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/lein-sealog "1.8.0"
+(defproject com.wallbrew/lein-sealog "1.9.0"
   :description "A Leiningen plugin for managing your changelog."
   :url "https://github.com/Wall-Brew-Co/lein-sealog"
   :license {:name         "MIT"

--- a/src/leiningen/sealog.clj
+++ b/src/leiningen/sealog.clj
@@ -1,9 +1,6 @@
 (ns leiningen.sealog
-  ;; The first line prints as the task description in `lein help`
-  "Update your changelog, programatically.
-
-   Main namespace for the sealog plugin.
-   Provides the entry point for leiningen and basic help functions."
+  ;; The ns docstring prints as the task description in `lein help`
+  "Update your changelog, programmatically."
   (:require [leiningen.core.main :as main]
             [leiningen.sealog.api :as sealog]))
 

--- a/src/leiningen/sealog.clj
+++ b/src/leiningen/sealog.clj
@@ -24,7 +24,7 @@
   (main/info "  render  - Render the changelog to the target file.")
   (main/info "  insert  - Insert a note of a specified change type into the most current change file.")
   (main/info "  version - Display information about the current version.")
-  (main/info "  check   - Check the current configuration, changelog etries, and the current project version.")
+  (main/info "  check   - Check the current configuration, changelog entries, and the current project version.")
   (main/info "  help    - Display this help message.")
   (main/info "")
   (main/info "Run `lein sealog help <command>` for more information on a specific command."))
@@ -70,7 +70,7 @@
   []
   (main/info "Usage: lein sealog insert <change-type> \"<change-message>\" \"<change-message>\" ...")
   (main/info "")
-  (main/info "Insert a note of a specfied `<change type> into the most current change file.")
+  (main/info "Insert a note of a specified `<change type> into the most current change file.")
   (main/info "Requires at least one `<change-message>` to be provided.")
   (main/info "However, multiple `<change-message>` can be provided.")
   (main/info "")
@@ -99,7 +99,7 @@
   []
   (main/info "Usage: lein sealog check")
   (main/info "")
-  (main/info "Check the current configuration, changelog etries, and the current project version.")
+  (main/info "Check the current configuration, changelog entries, and the current project version.")
   (main/info "Will exit abnormally if any issues are found.")
   (main/info "")
   (main/info "Checks:")
@@ -132,7 +132,7 @@
 
 
 (defn sealog
-  "Manage youur changelog, programatically."
+  "Manage your changelog, programmatically."
   [project & args]
   (let [command (first args)
         options (rest args)]

--- a/src/leiningen/sealog/impl/io.clj
+++ b/src/leiningen/sealog/impl/io.clj
@@ -38,10 +38,12 @@
   (main/info (format "Writing to %s" filename))
   (spit filename content))
 
+
 (defn ->pretty-string
   "Return `m` as a pretty printed string"
   [m]
   (with-out-str (pp/pprint m)))
+
 
 (defn write-edn-file!
   "Write the contents to a file as EDN."

--- a/src/leiningen/sealog/impl/io.clj
+++ b/src/leiningen/sealog/impl/io.clj
@@ -4,6 +4,7 @@
             [clojure.java.io :as io]
             [clojure.pprint :as pp]
             [clojure.spec.alpha :as spec]
+            [clojure.string :as str]
             [leiningen.core.main :as main]
             [spec-tools.core :as st]))
 
@@ -37,13 +38,19 @@
   (main/info (format "Writing to %s" filename))
   (spit filename content))
 
+(defn ->pretty-string
+  "Return `m` as a pretty printed string"
+  [m]
+  (with-out-str (pp/pprint m)))
 
 (defn write-edn-file!
   "Write the contents to a file as EDN."
-  [filename content {:keys [pretty-print-edn?]}]
-  (if pretty-print-edn?
-    (write-file! filename (with-out-str (pp/pprint content)))
-    (write-file! filename content)))
+  [filename content {:keys [pretty-print-edn? remove-commas-in-change-files?]}]
+  (let [beautified-content (cond-> content
+                             pretty-print-edn?              ->pretty-string
+                             (not pretty-print-edn?)        str
+                             remove-commas-in-change-files? (str/replace #"," ""))]
+    (write-file! filename beautified-content)))
 
 
 (defn read-file!

--- a/src/leiningen/sealog/types/config.clj
+++ b/src/leiningen/sealog/types/config.clj
@@ -41,10 +41,11 @@
     {:type        :boolean
      :description "Whether or not to pretty print the EDN files."}))
 
+
 (spec/def ::remove-commas-in-change-files?
   (st/spec
-   {:type :boolean
-    :description "Wether or not the map delimiter commas inserted by clojure.pprint should be removed when creating a new change file."}))
+    {:type :boolean
+     :description "Wether or not the map delimiter commas inserted by clojure.pprint should be removed when creating a new change file."}))
 
 
 (spec/def ::config

--- a/src/leiningen/sealog/types/config.clj
+++ b/src/leiningen/sealog/types/config.clj
@@ -41,6 +41,11 @@
     {:type        :boolean
      :description "Whether or not to pretty print the EDN files."}))
 
+(spec/def ::remove-commas-in-change-files?
+  (st/spec
+   {:type :boolean
+    :description "Ether or not the map delimiter commas inserted by clojure.pprint should be removed when creating a new change file."}))
+
 
 (spec/def ::config
   (st/spec
@@ -48,13 +53,15 @@
      :spec        (spec/keys :opt-un [::changelog-filename
                                       ::changelog-entry-directory
                                       ::version-scheme
-                                      ::pretty-print-edn?])
+                                      ::pretty-print-edn?
+                                      ::remove-commas-in-change-files?])
      :description "The configuration for Sealog."}))
 
 
 (def default-config
   "The default configuration for Sealog."
-  {:changelog-filename        "CHANGELOG.md"
-   :changelog-entry-directory ".sealog/changes/"
-   :version-scheme            :semver3
-   :pretty-print-edn?         false})
+  {:changelog-filename             "CHANGELOG.md"
+   :changelog-entry-directory      ".sealog/changes/"
+   :version-scheme                 :semver3
+   :pretty-print-edn?              false
+   :remove-commas-in-change-files? false})

--- a/src/leiningen/sealog/types/config.clj
+++ b/src/leiningen/sealog/types/config.clj
@@ -44,7 +44,7 @@
 (spec/def ::remove-commas-in-change-files?
   (st/spec
    {:type :boolean
-    :description "Ether or not the map delimiter commas inserted by clojure.pprint should be removed when creating a new change file."}))
+    :description "Wether or not the map delimiter commas inserted by clojure.pprint should be removed when creating a new change file."}))
 
 
 (spec/def ::config

--- a/test/leiningen/sealog/types/config_test.clj
+++ b/test/leiningen/sealog/types/config_test.clj
@@ -11,6 +11,7 @@
     (is (test-util/generatable? ::sut/changelog-entry-directory))
     (is (test-util/generatable? ::sut/version-scheme))
     (is (test-util/generatable? ::sut/pretty-print-edn?))
+    (is (test-util/generatable? ::sut/remove-commas-in-change-files?))
     (is (test-util/generatable? ::sut/config))))
 
 


### PR DESCRIPTION
# Proposed Changes

* Added
  * Added a new configuration key `:remove-commas-in-change-files?` to remove automatically printed commas in change entry files.

## Pre-merge Checklist

- [x] Read and agree to the Contribution Guidelines and Code of Conduct
- [x] Write new tests for impacted functionality
- [x] Update the CHANGELOG and increment version
- [x] Update the README and other relevant documentation
